### PR TITLE
Build with ott3.2

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -20,7 +20,7 @@ peyotl_git_remote: https://github.com/OpenTreeOfLife/peyotl
 peyotl_webapp_branch: master
 
 # next_synth_version should not be hard-coded
-next_synth_version: 11.4
+next_synth_version: 12.0
 
 otcetera_git_remote: https://github.com/OpenTreeOfLife/otcetera
 otcetera_synth_branch: bump_fossil_higher
@@ -32,9 +32,9 @@ taxomachine_branch: master
 ws_wrapper_git_remote: https://github.com/OpenTreeOfLife/ws_wrapper
 ws_wrapper_branch: master
 
-ott_synth_full_version: ott3.1
-ott_version: ott3.1
-ott_tag: 3.1.0
+ott_synth_full_version: ott3.2
+ott_version: ott3.2
+ott_tag: 3.2.0
 
 otc_ws_data: /home/{{normaluser}}/ws/otc_ws_data
 

--- a/roles/add-ots-ws-links-to-tree-and-taxonomy/tasks/main.yml
+++ b/roles/add-ots-ws-links-to-tree-and-taxonomy/tasks/main.yml
@@ -1,37 +1,16 @@
 ---
 
-- name: Check if archive of next synth has been created
-  stat:
-    path: "{{ synth_dir }}/tree_builds/opentree{{ next_synth_version }}.tgz"
-  register: synth_archive
+- name: Copy synth tree to served location.
+  copy:
+    src: "{{ synth_dir }}/tree_builds/opentree{{ next_synth_version }}"
+    dest: "{{ otc_ws_data }}/synth_trees/"
+    remote_src: true
+    mode: preserve
 
-- name: compress synth tree if required
-  archive:
-    path: "{{ synth_dir }}/tree_builds/opentree{{ next_synth_version }}"
-    dest: "{{ synth_dir }}/tree_builds/opentree{{ next_synth_version }}.tgz"
-  when: not synth_archive.stat.exists
+- name: Copy OTT to served location.
+  copy:
+    src: "{{ synth_dir }}/tree_builds/ott-used-in-synth"
+    dest: "{{ otc_ws_data }}/"
+    remote_src: true
+    mode: preserve
 
-- name: Check if archive of most recently used OTT has been created
-  stat:
-    path: "{{ synth_dir }}/tree_builds/ott-used-in-synth{{ next_synth_version }}.tgz"
-  register: synth_ott_archive
-
-- name: compress most recently used OTT if required
-  archive:
-    path: "{{ synth_dir }}/tree_builds/ott-used-in-synth"
-    dest: "{{ synth_dir }}/tree_builds/ott-used-in-synth{{ next_synth_version }}.tgz"
-  when: not synth_ott_archive.stat.exists
-
-- name: Uncompress synth tree
-  unarchive:
-    src: "{{ synth_dir }}/tree_builds/opentree{{ next_synth_version }}.tgz"
-    dest: "{{ otc_ws_data }}/synth_trees"
-    remote_src: yes
-    creates: "{{ otc_ws_data }}/synth_trees/opentree{{ next_synth_version }}"
-
-- name: Uncompress most recently used OTT
-  unarchive:
-    src: "{{ synth_dir }}/tree_builds/ott-used-in-synth{{ next_synth_version }}.tgz"
-    dest: "{{ otc_ws_data }}"
-    remote_src: yes
-    creates: "{{ otc_ws_data }}/ott-used-in-synth"


### PR DESCRIPTION
This branch replaces the archive/unarchive stuff with the "copy" module.  This works with ansible 2.8, but I think did not work with prior versions.

It is much much faster.

Are there some gotcha's about using the copy module?  To my perhaps naive eye, there are some gotchas but they are the same as the archive/unarchive approach.  Specifically, pickle files for the old taxonomy are not removed, because we overwrite old files but do not remove files that are no longer used.