### PR TITLE
We need to override opentree_branch for devtree.

### DIFF
--- a/hosts
+++ b/hosts
@@ -27,3 +27,4 @@ all:
         devtree:
           host: devtree
           ansible_host: devtree.opentreeoflife.org
+          opentree_branch: development


### PR DESCRIPTION
I think this is now required because of [this earlier change to roles/webapp/defaults](https://github.com/OpenTreeOfLife/ot-ansible/commit/062279a5065a81dd218580525b1211f9bf3f41e3#diff-58f33a7460a06371e4c34592d75a0ffb41ba8b798eff2912452fc20a0fc2e5e8L3-R3).

This version is deployed and working as expected on **devtree**. Previously it would always deploy the `master` branch of the webapps instead of `development`. 

@snacktavish Please let me know if this is (or should be) specified in another way. 