### PR TITLE
Install appropriate version of modwsgi python

### DIFF
--- a/playbk-build-phylesystem-api.yml
+++ b/playbk-build-phylesystem-api.yml
@@ -23,7 +23,7 @@
           - python3-virtualenv
           - unzip
           - daemonize
-          - libapache2-mod-wsgi-py3
+          - libapache2-mod-wsgi-py3  # python3 for Pyramids apps
         state: present
 
   vars:

--- a/playbk-install-webapp.yml
+++ b/playbk-install-webapp.yml
@@ -34,4 +34,6 @@
  
   roles:
     - webapp
-    - apache
+    - role: apache
+      vars:
+        modwsgi_python_version: libapache2-mod-wsgi      # python2 for web2py

--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -1,0 +1,1 @@
+modwsgi_python_version: libapache2-mod-wsgi-py3  # python3 for Pyramid apps

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -9,14 +9,13 @@
     state: present
 
 
-## TODO This needs an if stamenet for different roles/python versions. 
-#- name: Install mod-wsgi using apt
-#  become: yes
-#  remote_user: deploy
-#  apt:
-#    name:
-#      - libapache2-mod-wsgi
-#    state: present
+- name: Install mod-wsgi using apt (incl. {{ modwsgi_python_version }})
+  become: yes
+  remote_user: deploy
+  apt:
+    name:
+      - "{{ modwsgi_python_version }}"
+    state: present
 
   become_method: sudo
 


### PR DESCRIPTION
This is important while the web apps are still in web2py (python2). By default apache will expect Pyramid apps (python3).