### PR TITLE
Use some of our production API endpoints on dev

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -58,6 +58,8 @@ deploy_custom_synth: false
 
 # By default, study curation on tree (production) domain
 curation_webapp_url: https://tree.opentreeoflife.org/curator
+# Add explicit URL to *production* app, for testing on dev
+curation_production_webapp_url: https://tree.opentreeoflife.org/curator
 apis_production_base_URL: https://api.opentreeoflife.org
 
 ## This is used in the apache configs to redirect cached urls, and direct phylesystemapi calls

--- a/roles/webapp/templates/treeview_app_config.j2
+++ b/roles/webapp/templates/treeview_app_config.j2
@@ -18,6 +18,8 @@ github_app_installation_id = {{ treeview_github_app_installation_id }}
 [api_base_urls]
 default_apis = {{ apis_common_base_URL }}
 production_apis = {{ apis_production_base_URL }}
+# We'll also need the production hostname to link to its curation tool from dev
+curation_production_webapp_url = {{ curation_production_webapp_url }}
 # Cached versions of some APIs will speed up repeated calls (see below).
 # These use a simple web2py cache implemented in phylesystem-api
 CACHED_default_apis = {{ apis_common_base_URL }}/cached

--- a/roles/webapp/templates/treeview_app_config.j2
+++ b/roles/webapp/templates/treeview_app_config.j2
@@ -36,12 +36,12 @@ getDraftSubtree_url = {default_apis}/v3/tree_of_life/subtree
 doTNRSForAutocomplete_url = {default_apis}/v3/tnrs/autocomplete_name
 getContextsJSON_url = {CACHED_default_apis}/v3/tnrs/contexts
 getSynthesisSourceList_url = {CACHED_default_apis}/v3/tree_of_life/about
-findAllStudies_url = {CACHED_default_apis}/v3/studies/find_studies
-singlePropertySearchForStudies_url = {default_apis}/v3/studies/find_studies
-singlePropertySearchForTrees_url = {default_apis}/v3/studies/find_trees
+findAllStudies_url = {CACHED_production_apis}/v3/studies/find_studies
+singlePropertySearchForStudies_url = {production_apis}/v3/studies/find_studies
+singlePropertySearchForTrees_url = {production_apis}/v3/studies/find_trees
 getTaxonInfo_url = {default_apis}/v3/taxonomy/taxon_info
 # Include one phylesystem-api method to download NexSON from Bibliographic References page
-API_load_study_GET_url = {default_apis}/v3/study/{STUDY_ID}
+API_load_study_GET_url = {production_apis}/v3/study/{STUDY_ID}
 
 # The synth-tree viewer GUI includes links to a curation app. For "curatorless"
 # installations, this should point to a working public curation app.


### PR DESCRIPTION
_Reminder: This lets us point to production APIs when using our test/staging apps, since the dev environment has partial and out-of-date phylesystem repos vs. the synth-tree being served._

I've modified the dev config to use production APIs for calls involving source studies and trees. I've reviewed the source code to make sure these API methods aren't being used for multiple features, so there should be no weird side effects from this change.

This is working now on **devtree**. 